### PR TITLE
Apply standard Rust formatting using rustfmt

### DIFF
--- a/src/build_tool.rs
+++ b/src/build_tool.rs
@@ -1,6 +1,6 @@
 use crate::cache::Cache;
-use crate::{DEBUG, Lang};
 use crate::rust::Project;
+use crate::{Lang, DEBUG};
 
 pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, String) {
     match lang {
@@ -8,12 +8,12 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
             println!("Launch: {}", command_str);
             let code = std::fs::read_to_string("sandbox/src/lib.rs").unwrap();
             let dependencies = std::fs::read_to_string("sandbox/Cargo.toml").unwrap();
-            let src= format!("{}\n{}", dependencies, code);
+            let src = format!("{}\n{}", dependencies, code);
             let key = format!("{}{}", command_str, src);
             let result_str_opt = cache.get(&key);
             let result_str = match result_str_opt {
                 None => {
-                    let command_parts= command_str.split(" ").collect::<Vec<&str>>();
+                    let command_parts = command_str.split(" ").collect::<Vec<&str>>();
                     let args = command_parts[1..].to_vec();
                     let output = std::process::Command::new(command_parts[0])
                         .args(args)
@@ -28,9 +28,7 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
                     cache.set(key, json_str.clone());
                     json_str
                 }
-                Some(result) => {
-                    result.to_string()
-                }
+                Some(result) => result.to_string(),
             };
             let parsed: (i32, String) = serde_json::from_str(&result_str).unwrap();
 
@@ -46,16 +44,21 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
         }
         Lang::Java => {
             println!("Launch: {}", command_str);
-            let code = std::fs::read_to_string("sandbox/src/main/java/com/example/solution/Solution.java").unwrap();
-            let test = std::fs::read_to_string("sandbox/src/test/java/com/example/solution/SolutionTest.java").unwrap();
+            let code =
+                std::fs::read_to_string("sandbox/src/main/java/com/example/solution/Solution.java")
+                    .unwrap();
+            let test = std::fs::read_to_string(
+                "sandbox/src/test/java/com/example/solution/SolutionTest.java",
+            )
+            .unwrap();
             let code_and_test = format!("{}\n{}", code, test);
             let dependencies = std::fs::read_to_string("sandbox/pom.xml").unwrap();
-            let src= format!("{}\n{}", dependencies, code_and_test);
+            let src = format!("{}\n{}", dependencies, code_and_test);
             let key = format!("{}{}", command_str, src);
             let result_str_opt = cache.get(&key);
             let result_str = match result_str_opt {
                 None => {
-                    let command_parts= command_str.split(" ").collect::<Vec<&str>>();
+                    let command_parts = command_str.split(" ").collect::<Vec<&str>>();
                     let args = command_parts[1..].to_vec();
                     // check OS if windows then add ".cmd" to command name in command_parts[0]
                     let command = if cfg!(target_os = "windows") {
@@ -76,9 +79,7 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
                     cache.set(key, json_str.clone());
                     json_str
                 }
-                Some(result) => {
-                    result.to_string()
-                }
+                Some(result) => result.to_string(),
             };
             let parsed: (i32, String) = serde_json::from_str(&result_str).unwrap();
 
@@ -96,15 +97,16 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
         Lang::Scala => {
             println!("Launch: {}", command_str);
             let code = std::fs::read_to_string("sandbox/src/main/scala/Solution.scala").unwrap();
-            let test = std::fs::read_to_string("sandbox/src/test/scala/SolutionTest.scala").unwrap();
+            let test =
+                std::fs::read_to_string("sandbox/src/test/scala/SolutionTest.scala").unwrap();
             let code_and_test = format!("{}\n{}", code, test);
             let dependencies = std::fs::read_to_string("sandbox/build.sbt").unwrap();
-            let src= format!("{}\n{}", dependencies, code_and_test);
+            let src = format!("{}\n{}", dependencies, code_and_test);
             let key = format!("{}{}", command_str, src);
             let result_str_opt = cache.get(&key);
             let result_str = match result_str_opt {
                 None => {
-                    let command_parts= command_str.split(" ").collect::<Vec<&str>>();
+                    let command_parts = command_str.split(" ").collect::<Vec<&str>>();
                     let args = command_parts[1..].to_vec();
                     // check OS if windows then add ".cmd" to command name in command_parts[0]
                     let command = if cfg!(target_os = "windows") {
@@ -125,9 +127,7 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
                     cache.set(key, json_str.clone());
                     json_str
                 }
-                Some(result) => {
-                    result.to_string()
-                }
+                Some(result) => result.to_string(),
             };
             let parsed: (i32, String) = serde_json::from_str(&result_str).unwrap();
 
@@ -144,15 +144,16 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
         Lang::Swift => {
             println!("Launch: {}", command_str);
             let code = std::fs::read_to_string("sandbox/Sources/Solution/Solution.swift").unwrap();
-            let test = std::fs::read_to_string("sandbox/Tests/SolutionTests/SolutionTests.swift").unwrap();
+            let test =
+                std::fs::read_to_string("sandbox/Tests/SolutionTests/SolutionTests.swift").unwrap();
             let code_and_test = format!("{}\n{}", code, test);
             let dependencies = std::fs::read_to_string("sandbox/Package.swift").unwrap();
-            let src= format!("{}\n{}", dependencies, code_and_test);
+            let src = format!("{}\n{}", dependencies, code_and_test);
             let key = format!("{}{}", command_str, src);
             let result_str_opt = cache.get(&key);
             let result_str = match result_str_opt {
                 None => {
-                    let command_parts= command_str.split(" ").collect::<Vec<&str>>();
+                    let command_parts = command_str.split(" ").collect::<Vec<&str>>();
                     let args = command_parts[1..].to_vec();
                     // check OS if windows then add ".cmd" to command name in command_parts[0]
                     let command = command_parts[0].to_string();
@@ -169,9 +170,7 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
                     cache.set(key, json_str.clone());
                     json_str
                 }
-                Some(result) => {
-                    result.to_string()
-                }
+                Some(result) => result.to_string(),
             };
             let parsed: (i32, String) = serde_json::from_str(&result_str).unwrap();
 
@@ -191,12 +190,12 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
             let test = std::fs::read_to_string("sandbox/src/test/kotlin/SolutionTest.kt").unwrap();
             let code_and_test = format!("{}\n{}", code, test);
             let dependencies = std::fs::read_to_string("sandbox/build.gradle").unwrap();
-            let src= format!("{}\n{}", dependencies, code_and_test);
+            let src = format!("{}\n{}", dependencies, code_and_test);
             let key = format!("{}{}", command_str, src);
             let result_str_opt = cache.get(&key);
             let result_str = match result_str_opt {
                 None => {
-                    let command_parts= command_str.split(" ").collect::<Vec<&str>>();
+                    let command_parts = command_str.split(" ").collect::<Vec<&str>>();
                     let args = command_parts[1..].to_vec();
                     // check OS if windows then add ".cmd" to command name in command_parts[0]
                     let command = if cfg!(target_os = "windows") {
@@ -218,9 +217,7 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
                     cache.set(key, json_str.clone());
                     json_str
                 }
-                Some(result) => {
-                    result.to_string()
-                }
+                Some(result) => result.to_string(),
             };
             let parsed: (i32, String) = serde_json::from_str(&result_str).unwrap();
 
@@ -244,12 +241,12 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
             let test = std::fs::read_to_string("sandbox/test.py").unwrap();
             let code_and_test = format!("{}\n{}", code, test);
             let dependencies = std::fs::read_to_string("sandbox/requirements.txt").unwrap();
-            let src= format!("{}\n{}", dependencies, code_and_test);
+            let src = format!("{}\n{}", dependencies, code_and_test);
             let key = format!("{}{}", command_str, src);
             let result_str_opt = cache.get(&key);
             let result_str = match result_str_opt {
                 None => {
-                    let command_parts= command_str.split(" ").collect::<Vec<&str>>();
+                    let command_parts = command_str.split(" ").collect::<Vec<&str>>();
                     let args = command_parts[1..].to_vec();
                     let output = std::process::Command::new(command_parts[0])
                         .args(args)
@@ -264,9 +261,7 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
                     cache.set(key, json_str.clone());
                     json_str
                 }
-                Some(result) => {
-                    result.to_string()
-                }
+                Some(result) => result.to_string(),
             };
             let parsed: (i32, String) = serde_json::from_str(&result_str).unwrap();
 
@@ -287,12 +282,12 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
             let test = std::fs::read_to_string("sandbox/src/solution.test.js").unwrap();
             let code_and_test = format!("{}\n{}", code, test);
             let dependencies = std::fs::read_to_string("sandbox/package.json").unwrap();
-            let src= format!("{}\n{}", dependencies, code_and_test);
+            let src = format!("{}\n{}", dependencies, code_and_test);
             let key = format!("{}{}", command_str, src);
             let result_str_opt = cache.get(&key);
             let result_str = match result_str_opt {
                 None => {
-                    let command_parts= command_str.split(" ").collect::<Vec<&str>>();
+                    let command_parts = command_str.split(" ").collect::<Vec<&str>>();
                     let args = command_parts[1..].to_vec();
                     // check OS if windows then add ".cmd" to command name in command_parts[0]
                     let command = if cfg!(target_os = "windows") {
@@ -313,9 +308,7 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
                     cache.set(key, json_str.clone());
                     json_str
                 }
-                Some(result) => {
-                    result.to_string()
-                }
+                Some(result) => result.to_string(),
             };
             let parsed: (i32, String) = serde_json::from_str(&result_str).unwrap();
 
@@ -335,12 +328,12 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
             let test = std::fs::read_to_string("sandbox/tests/SolutionTest.php").unwrap();
             let code_and_test = format!("{}\n{}", code, test);
             let dependencies = std::fs::read_to_string("sandbox/composer.json").unwrap();
-            let src= format!("{}\n{}", dependencies, code_and_test);
+            let src = format!("{}\n{}", dependencies, code_and_test);
             let key = format!("{}{}", command_str, src);
             let result_str_opt = cache.get(&key);
             let result_str = match result_str_opt {
                 None => {
-                    let command_parts= command_str.split(" ").collect::<Vec<&str>>();
+                    let command_parts = command_str.split(" ").collect::<Vec<&str>>();
                     let args = command_parts[1..].to_vec();
                     // check OS if windows then add ".cmd" to command name in command_parts[0]
                     let command = if cfg!(target_os = "windows") {
@@ -364,9 +357,7 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
                     cache.set(key, json_str.clone());
                     json_str
                 }
-                Some(result) => {
-                    result.to_string()
-                }
+                Some(result) => result.to_string(),
             };
             let parsed: (i32, String) = serde_json::from_str(&result_str).unwrap();
 
@@ -381,15 +372,12 @@ pub fn build_tool(lang: &Lang, command_str: &str, cache: &mut Cache) -> (bool, S
             (exit_code_bool, only_error_message(&output, exit_code))
         }
         _ => panic!("Unsupported language: {:?}", lang),
-
     }
-
 }
 
 pub fn create_project_rust(lang: &Lang, project: &Project) {
     match lang {
         Lang::Rust => {
-
             println!("Create sandbox project with");
             println!("{}\n{}", project.cargo_toml, project.lib_rs);
             let sandbox_path = "sandbox";
@@ -406,34 +394,54 @@ pub fn create_project_rust(lang: &Lang, project: &Project) {
                 std::fs::create_dir(&src_path).unwrap();
             }
             std::fs::write(&main_path, &project.lib_rs).unwrap();
-            std::fs::write(&cargo_path, &project.cargo_toml ).unwrap();
+            std::fs::write(&cargo_path, &project.cargo_toml).unwrap();
         }
         _ => panic!("Unsupported language: {:?}", lang),
     }
 }
 pub fn create_project_java(project: &crate::java::Project) {
-        println!("Create sandbox project with");
-        println!("{}\n{}\n{}", project.project_build_script, project.solution_code, project.test_code);
-        let sandbox_path = "sandbox";
+    println!("Create sandbox project with");
+    println!(
+        "{}\n{}\n{}",
+        project.project_build_script, project.solution_code, project.test_code
+    );
+    let sandbox_path = "sandbox";
 
-        let main_path = format!("{}/src/main/java/com/example/solution/Solution.java", sandbox_path);
-        let test_path = format!("{}/src/test/java/com/example/solution/SolutionTest.java", sandbox_path);
-        let pom_path = format!("{}/pom.xml", sandbox_path);
-        if !std::path::Path::new(sandbox_path).exists() {
-            std::fs::create_dir(sandbox_path).unwrap();
-        } else {
-            std::fs::remove_dir_all(sandbox_path).unwrap();
-            std::fs::create_dir(sandbox_path).unwrap();
-        }
-        std::fs::create_dir_all(format!("{}/src/main/java/com/example/solution", sandbox_path)).unwrap();
-        std::fs::create_dir_all(format!("{}/src/test/java/com/example/solution", sandbox_path)).unwrap();
-        std::fs::write(&main_path, &project.solution_code).unwrap();
-        std::fs::write(&test_path, &project.test_code).unwrap();
-        std::fs::write(&pom_path, &project.project_build_script).unwrap();
+    let main_path = format!(
+        "{}/src/main/java/com/example/solution/Solution.java",
+        sandbox_path
+    );
+    let test_path = format!(
+        "{}/src/test/java/com/example/solution/SolutionTest.java",
+        sandbox_path
+    );
+    let pom_path = format!("{}/pom.xml", sandbox_path);
+    if !std::path::Path::new(sandbox_path).exists() {
+        std::fs::create_dir(sandbox_path).unwrap();
+    } else {
+        std::fs::remove_dir_all(sandbox_path).unwrap();
+        std::fs::create_dir(sandbox_path).unwrap();
+    }
+    std::fs::create_dir_all(format!(
+        "{}/src/main/java/com/example/solution",
+        sandbox_path
+    ))
+    .unwrap();
+    std::fs::create_dir_all(format!(
+        "{}/src/test/java/com/example/solution",
+        sandbox_path
+    ))
+    .unwrap();
+    std::fs::write(&main_path, &project.solution_code).unwrap();
+    std::fs::write(&test_path, &project.test_code).unwrap();
+    std::fs::write(&pom_path, &project.project_build_script).unwrap();
 }
 pub fn create_project_scala(project: &crate::java::Project) {
     println!("Create sandbox project with");
-    println!("{}\n{}\n{}", project.project_build_script, project.solution_code, project.test_code);
+    println!(
+        "{}\n{}\n{}",
+        project.project_build_script, project.solution_code, project.test_code
+    );
     let sandbox_path = "sandbox";
 
     let main_path = format!("{}/src/main/scala/Solution.scala", sandbox_path);
@@ -453,7 +461,10 @@ pub fn create_project_scala(project: &crate::java::Project) {
 }
 pub fn create_project_swift(project: &crate::java::Project) {
     println!("Create sandbox project with");
-    println!("{}\n{}\n{}", project.project_build_script, project.solution_code, project.test_code);
+    println!(
+        "{}\n{}\n{}",
+        project.project_build_script, project.solution_code, project.test_code
+    );
     let sandbox_path = "sandbox";
 
     let main_path = format!("{}/Sources/Solution/Solution.swift", sandbox_path);
@@ -473,7 +484,10 @@ pub fn create_project_swift(project: &crate::java::Project) {
 }
 pub fn create_project_kotlin(project: &crate::java::Project) {
     println!("Create sandbox project with");
-    println!("{}\n{}\n{}", project.project_build_script, project.solution_code, project.test_code);
+    println!(
+        "{}\n{}\n{}",
+        project.project_build_script, project.solution_code, project.test_code
+    );
     let sandbox_path = "sandbox";
 
     let main_path = format!("{}/src/main/kotlin/Solution.kt", sandbox_path);
@@ -493,7 +507,10 @@ pub fn create_project_kotlin(project: &crate::java::Project) {
 }
 pub fn create_project_python(project: &crate::java::Project) {
     println!("Create sandbox project with");
-    println!("{}\n{}\n{}", project.project_build_script, project.solution_code, project.test_code);
+    println!(
+        "{}\n{}\n{}",
+        project.project_build_script, project.solution_code, project.test_code
+    );
     let sandbox_path = "sandbox";
 
     let main_path = format!("{}/solution.py", sandbox_path);
@@ -512,7 +529,10 @@ pub fn create_project_python(project: &crate::java::Project) {
 
 pub fn create_project_javascript(project: &crate::java::Project) {
     println!("Create sandbox project with");
-    println!("{}\n{}\n{}", project.project_build_script, project.solution_code, project.test_code);
+    println!(
+        "{}\n{}\n{}",
+        project.project_build_script, project.solution_code, project.test_code
+    );
     let sandbox_path = "sandbox";
 
     let main_path = format!("{}/src/solution.js", sandbox_path);
@@ -531,7 +551,10 @@ pub fn create_project_javascript(project: &crate::java::Project) {
 }
 pub fn create_project_php(project: &crate::java::Project) {
     println!("Create sandbox project with");
-    println!("{}\n{}\n{}", project.project_build_script, project.solution_code, project.test_code);
+    println!(
+        "{}\n{}\n{}",
+        project.project_build_script, project.solution_code, project.test_code
+    );
     let sandbox_path = "sandbox";
     let main_path = format!("{}/src/Solution.php", sandbox_path);
     let test_path = format!("{}/tests/SolutionTest.php", sandbox_path);
@@ -549,10 +572,9 @@ pub fn create_project_php(project: &crate::java::Project) {
     std::fs::write(&pom_path, &project.project_build_script).unwrap();
 }
 
-
 fn only_error_message(output: &str, exit_code: i32) -> String {
     if exit_code == 0 {
-        return "".to_string()
+        return "".to_string();
     } else {
         output.to_string()
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,5 +1,5 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Cache {
@@ -44,7 +44,7 @@ impl Cache {
         std::fs::write("cache.json", json).unwrap();
     }
 
-    fn restore(&mut self)  {
+    fn restore(&mut self) {
         if !std::path::Path::new("cache.json").exists() {
             return;
         }

--- a/src/java.rs
+++ b/src/java.rs
@@ -1,5 +1,5 @@
-use regex::Regex;
 use crate::rust::remove_comments;
+use regex::Regex;
 
 #[derive(Debug)]
 pub struct Project {
@@ -17,7 +17,8 @@ pub fn parse_llm_response(response: &str) -> Project {
     let mut build = String::new();
     let mut test = String::new();
 
-    let re_section = Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
+    let re_section =
+        Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
 
     let mut positions = Vec::new();
 
@@ -46,7 +47,8 @@ pub fn parse_llm_response(response: &str) -> Project {
                 pom_xml = content;
             } else if section_name.contains("src/main/java/com/example/solution/Solution.java") {
                 solution_java = content;
-            } else if section_name.contains("src/test/java/com/example/solution/SolutionTest.java") {
+            } else if section_name.contains("src/test/java/com/example/solution/SolutionTest.java")
+            {
                 test_java = content;
             } else if section_name.contains("Compile") {
                 build = content;
@@ -57,7 +59,6 @@ pub fn parse_llm_response(response: &str) -> Project {
     }
 
     if pom_xml == "" {
-
         let mut lines = response.lines().peekable();
 
         while let Some(line) = lines.next() {
@@ -82,8 +83,12 @@ pub fn parse_llm_response(response: &str) -> Project {
                         // Assign the captured content to the appropriate field
                         match section_title {
                             "pom.xml" => pom_xml = code_content.trim_end().to_string(),
-                            "src/main/java/com/example/solution/Solution.java" => solution_java = code_content.trim_end().to_string(),
-                            "src/test/java/com/example/solution/SolutionTest.java" => test_java = code_content.trim_end().to_string(),
+                            "src/main/java/com/example/solution/Solution.java" => {
+                                solution_java = code_content.trim_end().to_string()
+                            }
+                            "src/test/java/com/example/solution/SolutionTest.java" => {
+                                test_java = code_content.trim_end().to_string()
+                            }
                             "Compile" => build = code_content.trim_end().to_string(),
                             "Test" => test = code_content.trim_end().to_string(),
                             _ => (),
@@ -103,8 +108,7 @@ pub fn parse_llm_response(response: &str) -> Project {
             build: remove_comments(&build),
             test: remove_comments(&test),
         }
-    }
-    else {
+    } else {
         Project {
             project_build_script: pom_xml,
             solution_code: solution_java,
@@ -114,7 +118,6 @@ pub fn parse_llm_response(response: &str) -> Project {
         }
     }
 }
-
 
 mod tests {
 
@@ -132,6 +135,5 @@ mod tests {
             assert!(!project.build.is_empty());
             assert!(!project.test.is_empty());
         }
-
     }
 }

--- a/src/javascript.rs
+++ b/src/javascript.rs
@@ -1,6 +1,6 @@
-use regex::Regex;
 use crate::java::Project;
 use crate::rust::remove_comments;
+use regex::Regex;
 
 pub fn parse_llm_response(response: &str) -> Project {
     let mut pom_xml = String::new();
@@ -9,7 +9,8 @@ pub fn parse_llm_response(response: &str) -> Project {
     let mut build = String::new();
     let mut test = String::new();
 
-    let re_section = Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
+    let re_section =
+        Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
 
     let mut positions = Vec::new();
 
@@ -73,8 +74,12 @@ pub fn parse_llm_response(response: &str) -> Project {
                         // Assign the captured content to the appropriate field
                         match section_title {
                             "package.json" => pom_xml = code_content.trim_end().to_string(),
-                            "src/solution.js" => solution_java = code_content.trim_end().to_string(),
-                            "src/solution.test.js" => test_java = code_content.trim_end().to_string(),
+                            "src/solution.js" => {
+                                solution_java = code_content.trim_end().to_string()
+                            }
+                            "src/solution.test.js" => {
+                                test_java = code_content.trim_end().to_string()
+                            }
                             "Install" => build = code_content.trim_end().to_string(),
                             "Test" => test = code_content.trim_end().to_string(),
                             _ => (),
@@ -94,8 +99,7 @@ pub fn parse_llm_response(response: &str) -> Project {
             build: remove_comments(&build),
             test: remove_comments(&test),
         }
-    }
-    else {
+    } else {
         Project {
             project_build_script: pom_xml,
             solution_code: solution_java,
@@ -105,4 +109,3 @@ pub fn parse_llm_response(response: &str) -> Project {
         }
     }
 }
-

--- a/src/kotlin.rs
+++ b/src/kotlin.rs
@@ -1,6 +1,6 @@
-use regex::Regex;
 use crate::java::Project;
 use crate::rust::remove_comments;
+use regex::Regex;
 
 pub fn parse_llm_response(response: &str) -> Project {
     let mut pom_xml = String::new();
@@ -9,7 +9,8 @@ pub fn parse_llm_response(response: &str) -> Project {
     let mut build = String::new();
     let mut test = String::new();
 
-    let re_section = Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
+    let re_section =
+        Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
 
     let mut positions = Vec::new();
 
@@ -49,7 +50,6 @@ pub fn parse_llm_response(response: &str) -> Project {
     }
 
     if pom_xml == "" {
-
         let mut lines = response.lines().peekable();
 
         while let Some(line) = lines.next() {
@@ -74,8 +74,12 @@ pub fn parse_llm_response(response: &str) -> Project {
                         // Assign the captured content to the appropriate field
                         match section_title {
                             "build.gradle" => pom_xml = code_content.trim_end().to_string(),
-                            "src/main/kotlin/Solution.scala" => solution_java = code_content.trim_end().to_string(),
-                            "src/test/kotlin/SolutionTest.scala" => test_java = code_content.trim_end().to_string(),
+                            "src/main/kotlin/Solution.scala" => {
+                                solution_java = code_content.trim_end().to_string()
+                            }
+                            "src/test/kotlin/SolutionTest.scala" => {
+                                test_java = code_content.trim_end().to_string()
+                            }
                             "Compile" => build = code_content.trim_end().to_string(),
                             "Test" => test = code_content.trim_end().to_string(),
                             _ => (),
@@ -95,8 +99,7 @@ pub fn parse_llm_response(response: &str) -> Project {
             build: remove_comments(&build),
             test: remove_comments(&test),
         }
-    }
-    else {
+    } else {
         Project {
             project_build_script: pom_xml,
             solution_code: solution_java,
@@ -106,4 +109,3 @@ pub fn parse_llm_response(response: &str) -> Project {
         }
     }
 }
-

--- a/src/llm_prompt.rs
+++ b/src/llm_prompt.rs
@@ -20,7 +20,7 @@ impl Prompt {
                     prompt_content = replace_last_multiple_return_to_one(&prompt_content);
                     prompts.prompts.insert(prompt_name, prompt_content);
                 }
-                prompt_name = line[3..line.len()-3].to_string();
+                prompt_name = line[3..line.len() - 3].to_string();
                 prompt_content = String::new();
             } else {
                 prompt_content.push_str(line);
@@ -30,9 +30,7 @@ impl Prompt {
         prompt_content = replace_last_multiple_return_to_one(&prompt_content);
         prompts.prompts.insert(prompt_name, prompt_content);
 
-
         prompts
-
     }
 
     pub fn create(&self, key: &str, params: &Vec<String>) -> String {
@@ -40,8 +38,6 @@ impl Prompt {
         prompt = construct_prompt(&prompt, params);
         prompt
     }
-
-
 }
 
 fn construct_prompt(template: &str, replace: &Vec<String>) -> String {
@@ -56,7 +52,6 @@ fn construct_prompt(template: &str, replace: &Vec<String>) -> String {
     prompt
 }
 
-
 fn replace_last_multiple_return_to_one(input: &str) -> String {
     let trimmed = input.trim_end_matches('\n');
     let mut result = String::from(trimmed);
@@ -65,8 +60,6 @@ fn replace_last_multiple_return_to_one(input: &str) -> String {
     }
     result
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/php.rs
+++ b/src/php.rs
@@ -1,6 +1,6 @@
-use regex::Regex;
 use crate::java::Project;
 use crate::rust::remove_comments;
+use regex::Regex;
 
 pub fn parse_llm_response(response: &str) -> Project {
     let mut pom_xml = String::new();
@@ -9,7 +9,8 @@ pub fn parse_llm_response(response: &str) -> Project {
     let mut build = String::new();
     let mut test = String::new();
 
-    let re_section = Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
+    let re_section =
+        Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
     let mut positions = Vec::new();
 
     for cap in re_section.captures_iter(response) {
@@ -72,8 +73,12 @@ pub fn parse_llm_response(response: &str) -> Project {
                         // Assign the captured content to the appropriate field
                         match section_title {
                             "composer.json" => pom_xml = code_content.trim_end().to_string(),
-                            "src/Solution.php" => solution_php = code_content.trim_end().to_string(),
-                            "tests/SolutionTest.php" => test_php = code_content.trim_end().to_string(),
+                            "src/Solution.php" => {
+                                solution_php = code_content.trim_end().to_string()
+                            }
+                            "tests/SolutionTest.php" => {
+                                test_php = code_content.trim_end().to_string()
+                            }
                             "Install" => build = code_content.trim_end().to_string(),
                             "Test" => test = code_content.trim_end().to_string(),
                             _ => (),
@@ -93,8 +98,7 @@ pub fn parse_llm_response(response: &str) -> Project {
             build: remove_comments(&build),
             test: remove_comments(&test),
         }
-    }
-    else {
+    } else {
         Project {
             project_build_script: pom_xml,
             solution_code: solution_php,

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,6 +1,6 @@
-use regex::Regex;
 use crate::java::Project;
 use crate::rust::remove_comments;
+use regex::Regex;
 
 pub fn parse_llm_response(response: &str) -> Project {
     let mut pom_xml = String::new();
@@ -9,7 +9,8 @@ pub fn parse_llm_response(response: &str) -> Project {
     let mut build = String::new();
     let mut test = String::new();
 
-    let re_section = Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
+    let re_section =
+        Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
 
     let mut positions = Vec::new();
 
@@ -49,7 +50,6 @@ pub fn parse_llm_response(response: &str) -> Project {
     }
 
     if pom_xml == "" {
-
         let mut lines = response.lines().peekable();
 
         while let Some(line) = lines.next() {
@@ -95,8 +95,7 @@ pub fn parse_llm_response(response: &str) -> Project {
             build: remove_comments(&build),
             test: remove_comments(&test),
         }
-    }
-    else {
+    } else {
         Project {
             project_build_script: pom_xml,
             solution_code: solution_java,
@@ -106,4 +105,3 @@ pub fn parse_llm_response(response: &str) -> Project {
         }
     }
 }
-

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -14,7 +14,8 @@ pub fn parse_llm_response(response: &str) -> Project {
     let mut build = String::new();
     let mut test = String::new();
 
-    let re_section = Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
+    let re_section =
+        Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
 
     let mut positions = Vec::new();
 
@@ -52,8 +53,6 @@ pub fn parse_llm_response(response: &str) -> Project {
     }
 
     if cargo_toml == "" {
-
-
         let mut lines = response.lines().peekable();
 
         while let Some(line) = lines.next() {
@@ -97,8 +96,7 @@ pub fn parse_llm_response(response: &str) -> Project {
             build: remove_comments(&build),
             test: remove_comments(&test),
         }
-    }
-    else {
+    } else {
         Project {
             cargo_toml,
             lib_rs,
@@ -110,7 +108,11 @@ pub fn parse_llm_response(response: &str) -> Project {
 
 pub fn remove_comments(text: &str) -> String {
     let re_comment = Regex::new(r"(?m)^#.*$").unwrap();
-    re_comment.replace_all(text, "").to_string().trim().to_string()
+    re_comment
+        .replace_all(text, "")
+        .to_string()
+        .trim()
+        .to_string()
 }
 mod tests {
 
@@ -129,6 +131,5 @@ mod tests {
             assert!(!project.build.is_empty());
             assert!(!project.test.is_empty());
         }
-
     }
 }

--- a/src/scala.rs
+++ b/src/scala.rs
@@ -1,6 +1,6 @@
-use regex::Regex;
 use crate::java::Project;
 use crate::rust::remove_comments;
+use regex::Regex;
 
 pub fn parse_llm_response(response: &str) -> Project {
     let mut pom_xml = String::new();
@@ -9,7 +9,8 @@ pub fn parse_llm_response(response: &str) -> Project {
     let mut build = String::new();
     let mut test = String::new();
 
-    let re_section = Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
+    let re_section =
+        Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
 
     let mut positions = Vec::new();
 
@@ -49,7 +50,6 @@ pub fn parse_llm_response(response: &str) -> Project {
     }
 
     if pom_xml == "" {
-
         let mut lines = response.lines().peekable();
 
         while let Some(line) = lines.next() {
@@ -74,8 +74,12 @@ pub fn parse_llm_response(response: &str) -> Project {
                         // Assign the captured content to the appropriate field
                         match section_title {
                             "build.sbt" => pom_xml = code_content.trim_end().to_string(),
-                            "src/main/scala/Solution.scala" => solution_java = code_content.trim_end().to_string(),
-                            "src/test/scala/SolutionTest.scala" => test_java = code_content.trim_end().to_string(),
+                            "src/main/scala/Solution.scala" => {
+                                solution_java = code_content.trim_end().to_string()
+                            }
+                            "src/test/scala/SolutionTest.scala" => {
+                                test_java = code_content.trim_end().to_string()
+                            }
                             "Compile" => build = code_content.trim_end().to_string(),
                             "Test" => test = code_content.trim_end().to_string(),
                             _ => (),
@@ -95,8 +99,7 @@ pub fn parse_llm_response(response: &str) -> Project {
             build: remove_comments(&build),
             test: remove_comments(&test),
         }
-    }
-    else {
+    } else {
         Project {
             project_build_script: pom_xml,
             solution_code: solution_java,
@@ -106,4 +109,3 @@ pub fn parse_llm_response(response: &str) -> Project {
         }
     }
 }
-

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -1,15 +1,18 @@
-use crate::build_tool::{build_tool, create_project_java, create_project_javascript, create_project_kotlin, create_project_php, create_project_python, create_project_rust, create_project_scala, create_project_swift};
+use crate::build_tool::{
+    build_tool, create_project_java, create_project_javascript, create_project_kotlin,
+    create_project_php, create_project_python, create_project_rust, create_project_scala,
+    create_project_swift,
+};
 use crate::cache::Cache;
-use crate::{Lang, MAX_NUMBER_OF_ATTEMPTS};
-use crate::llm_prompt::Prompt;
 use crate::llm_api::LLMApi;
-
+use crate::llm_prompt::Prompt;
+use crate::{Lang, MAX_NUMBER_OF_ATTEMPTS};
 
 pub fn run_state_machine(
     lang: &Lang,
     question: &str,
     prompt: &Prompt,
-    cache:  &mut Cache,
+    cache: &mut Cache,
     llm: &LLMApi,
 ) {
     match lang {
@@ -36,15 +39,20 @@ pub fn run_state_machine(
                         break;
                     }
                     number_of_attempts += 1;
-                    let result = llm.request("rewrite",
-                                             &vec![project.cargo_toml,
-                                                   project.lib_rs,
-                                                   project.build,
-                                                   build_res.1,
-                                                   project.test,
-                                                   test_res.1,
-                                                   question.to_string()],
-                                             cache, prompt);
+                    let result = llm.request(
+                        "rewrite",
+                        &vec![
+                            project.cargo_toml,
+                            project.lib_rs,
+                            project.build,
+                            build_res.1,
+                            project.test,
+                            test_res.1,
+                            question.to_string(),
+                        ],
+                        cache,
+                        prompt,
+                    );
                     project = crate::rust::parse_llm_response(&result);
                     println!("================");
                     println!("{:#?}", project);
@@ -84,16 +92,21 @@ pub fn run_state_machine(
                         break;
                     }
                     number_of_attempts += 1;
-                    let result = llm.request("rewrite",
-                                             &vec![project.project_build_script,
-                                                   project.solution_code,
-                                                   project.test_code,
-                                                   project.build,
-                                                   build_res.1,
-                                                   project.test,
-                                                   test_res.1,
-                                                   question.to_string()],
-                                             cache, prompt);
+                    let result = llm.request(
+                        "rewrite",
+                        &vec![
+                            project.project_build_script,
+                            project.solution_code,
+                            project.test_code,
+                            project.build,
+                            build_res.1,
+                            project.test,
+                            test_res.1,
+                            question.to_string(),
+                        ],
+                        cache,
+                        prompt,
+                    );
                     project = crate::java::parse_llm_response(&result);
                     println!("================");
                     println!("{:#?}", project);
@@ -133,16 +146,21 @@ pub fn run_state_machine(
                         break;
                     }
                     number_of_attempts += 1;
-                    let result = llm.request("rewrite",
-                                             &vec![project.project_build_script,
-                                                   project.solution_code,
-                                                   project.test_code,
-                                                   project.build,
-                                                   build_res.1,
-                                                   project.test,
-                                                   test_res.1,
-                                                   question.to_string()],
-                                             cache, prompt);
+                    let result = llm.request(
+                        "rewrite",
+                        &vec![
+                            project.project_build_script,
+                            project.solution_code,
+                            project.test_code,
+                            project.build,
+                            build_res.1,
+                            project.test,
+                            test_res.1,
+                            question.to_string(),
+                        ],
+                        cache,
+                        prompt,
+                    );
                     project = crate::scala::parse_llm_response(&result);
                     println!("================");
                     println!("{:#?}", project);
@@ -182,16 +200,21 @@ pub fn run_state_machine(
                         break;
                     }
                     number_of_attempts += 1;
-                    let result = llm.request("rewrite",
-                                             &vec![project.project_build_script,
-                                                   project.solution_code,
-                                                   project.test_code,
-                                                   project.build,
-                                                   build_res.1,
-                                                   project.test,
-                                                   test_res.1,
-                                                   question.to_string()],
-                                             cache, prompt);
+                    let result = llm.request(
+                        "rewrite",
+                        &vec![
+                            project.project_build_script,
+                            project.solution_code,
+                            project.test_code,
+                            project.build,
+                            build_res.1,
+                            project.test,
+                            test_res.1,
+                            question.to_string(),
+                        ],
+                        cache,
+                        prompt,
+                    );
                     project = crate::swift::parse_llm_response(&result);
                     println!("================");
                     println!("{:#?}", project);
@@ -231,16 +254,21 @@ pub fn run_state_machine(
                         break;
                     }
                     number_of_attempts += 1;
-                    let result = llm.request("rewrite",
-                                             &vec![project.project_build_script,
-                                                   project.solution_code,
-                                                   project.test_code,
-                                                   project.build,
-                                                   build_res.1,
-                                                   project.test,
-                                                   test_res.1,
-                                                   question.to_string()],
-                                             cache, prompt);
+                    let result = llm.request(
+                        "rewrite",
+                        &vec![
+                            project.project_build_script,
+                            project.solution_code,
+                            project.test_code,
+                            project.build,
+                            build_res.1,
+                            project.test,
+                            test_res.1,
+                            question.to_string(),
+                        ],
+                        cache,
+                        prompt,
+                    );
                     project = crate::kotlin::parse_llm_response(&result);
                     println!("================");
                     println!("{:#?}", project);
@@ -280,16 +308,21 @@ pub fn run_state_machine(
                         break;
                     }
                     number_of_attempts += 1;
-                    let result = llm.request("rewrite",
-                                             &vec![project.project_build_script,
-                                                   project.solution_code,
-                                                   project.test_code,
-                                                   project.build,
-                                                   build_res.1,
-                                                   project.test,
-                                                   test_res.1,
-                                                   question.to_string()],
-                                             cache, prompt);
+                    let result = llm.request(
+                        "rewrite",
+                        &vec![
+                            project.project_build_script,
+                            project.solution_code,
+                            project.test_code,
+                            project.build,
+                            build_res.1,
+                            project.test,
+                            test_res.1,
+                            question.to_string(),
+                        ],
+                        cache,
+                        prompt,
+                    );
                     project = crate::python::parse_llm_response(&result);
                     println!("================");
                     println!("{:#?}", project);
@@ -329,16 +362,21 @@ pub fn run_state_machine(
                         break;
                     }
                     number_of_attempts += 1;
-                    let result = llm.request("rewrite",
-                                             &vec![project.project_build_script,
-                                                   project.solution_code,
-                                                   project.test_code,
-                                                   project.build,
-                                                   build_res.1,
-                                                   project.test,
-                                                   test_res.1,
-                                                   question.to_string()],
-                                             cache, prompt);
+                    let result = llm.request(
+                        "rewrite",
+                        &vec![
+                            project.project_build_script,
+                            project.solution_code,
+                            project.test_code,
+                            project.build,
+                            build_res.1,
+                            project.test,
+                            test_res.1,
+                            question.to_string(),
+                        ],
+                        cache,
+                        prompt,
+                    );
                     project = crate::javascript::parse_llm_response(&result);
                     println!("================");
                     println!("{:#?}", project);
@@ -378,16 +416,21 @@ pub fn run_state_machine(
                         break;
                     }
                     number_of_attempts += 1;
-                    let result = llm.request("rewrite",
-                                             &vec![project.project_build_script,
-                                                   project.solution_code,
-                                                   project.test_code,
-                                                   project.build,
-                                                   build_res.1,
-                                                   project.test,
-                                                   test_res.1,
-                                                   question.to_string()],
-                                             cache, prompt);
+                    let result = llm.request(
+                        "rewrite",
+                        &vec![
+                            project.project_build_script,
+                            project.solution_code,
+                            project.test_code,
+                            project.build,
+                            build_res.1,
+                            project.test,
+                            test_res.1,
+                            question.to_string(),
+                        ],
+                        cache,
+                        prompt,
+                    );
                     project = crate::php::parse_llm_response(&result);
                     println!("================");
                     println!("{:#?}", project);
@@ -409,5 +452,4 @@ pub fn run_state_machine(
             panic!("Unknown lang: {}", lang);
         }
     }
-
 }

--- a/src/swift.rs
+++ b/src/swift.rs
@@ -1,6 +1,6 @@
-use regex::Regex;
 use crate::java::Project;
 use crate::rust::remove_comments;
+use regex::Regex;
 
 pub fn parse_llm_response(response: &str) -> Project {
     let mut pom_xml = String::new();
@@ -9,7 +9,8 @@ pub fn parse_llm_response(response: &str) -> Project {
     let mut build = String::new();
     let mut test = String::new();
 
-    let re_section = Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
+    let re_section =
+        Regex::new(r"(?m)^(?:\s*(?:\#*)?\s*\*\*)?(?:\d+\.\s*)?(.*?)[:\*]*\*\*\s*$").unwrap();
 
     let mut positions = Vec::new();
 
@@ -49,7 +50,6 @@ pub fn parse_llm_response(response: &str) -> Project {
     }
 
     if pom_xml == "" {
-
         let mut lines = response.lines().peekable();
 
         while let Some(line) = lines.next() {
@@ -74,8 +74,12 @@ pub fn parse_llm_response(response: &str) -> Project {
                         // Assign the captured content to the appropriate field
                         match section_title {
                             "Package.swift" => pom_xml = code_content.trim_end().to_string(),
-                            "Sources/Solution/main.swift" => solution_java = code_content.trim_end().to_string(),
-                            "Tests/SolutionTests/SolutionTests.swift" => test_java = code_content.trim_end().to_string(),
+                            "Sources/Solution/main.swift" => {
+                                solution_java = code_content.trim_end().to_string()
+                            }
+                            "Tests/SolutionTests/SolutionTests.swift" => {
+                                test_java = code_content.trim_end().to_string()
+                            }
                             "Compile" => build = code_content.trim_end().to_string(),
                             "Test" => test = code_content.trim_end().to_string(),
                             _ => (),
@@ -95,8 +99,7 @@ pub fn parse_llm_response(response: &str) -> Project {
             build: remove_comments(&build),
             test: remove_comments(&test),
         }
-    }
-    else {
+    } else {
         Project {
             project_build_script: pom_xml,
             solution_code: solution_java,
@@ -106,4 +109,3 @@ pub fn parse_llm_response(response: &str) -> Project {
         }
     }
 }
-


### PR DESCRIPTION
This PR applies Rust's standard formatting using cargo fmt to improve code consistency and readability.

Following these widely adopted conventions can make the codebase easier to maintain and contribute to, as it aligns with best practices within the Rust community. This change does not introduce any functional modifications—it's purely a stylistic update for consistency.

If there are any specific formatting preferences you'd like to maintain, I'd be happy to help configure them in a rustfmt.toml file. However, in most cases, the default formatting provided by Rust should suffice.

Formatting Code
To keep the code consistent going forward, it's recommended to run cargo fmt before submitting a pull request. This will help ensure the code follows Rust's standard formatting.